### PR TITLE
Fix ignoring middle field of home template

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -64,9 +64,9 @@
 		</template>
 		<template label="3col" path="core/layout/templates/3col.tpl">
 			<positions>
-			<position name="left"/>
-			<position name="right"/>
-			<position name="middle"/>
+				<position name="left"/>
+				<position name="middle"/>
+				<position name="right"/>
 				<position name="search">
 					<defaults>
 						<widget module="search" action="form" />


### PR DESCRIPTION
Middle and center were used both to target one position which gave problems when saving a page.

E.g. in info.xml the name _center_ was already used: https://github.com/ikoene/bootstrap-theme/blob/master/info.xml#L48

After merging the name _center_ is used consequently through the theme.
